### PR TITLE
Add support for Modern LaTeX delimiters

### DIFF
--- a/dev/lib/math-flow.js
+++ b/dev/lib/math-flow.js
@@ -7,222 +7,191 @@ import {factorySpace} from 'micromark-factory-space'
 import {markdownLineEnding} from 'micromark-util-character'
 import {codes, constants, types} from 'micromark-util-symbol'
 
-/** @type {Construct} */
-export const mathFlow = {
-  tokenize: tokenizeMathFenced,
-  concrete: true,
-  name: 'mathFlow'
-}
-
-/** @type {Construct} */
-const nonLazyContinuation = {
-  tokenize: tokenizeNonLazyContinuation,
-  partial: true
-}
-
 /**
- * @this {TokenizeContext}
- * @type {Tokenizer}
+ * @param {boolean} isLatexDelimiters
+ *   When true, looks for modern LaTeX delimiters like \[ ... \].
+ *   When false, looks for legacy TeX delimiters like $$...$$
+ * @returns {Construct}
+ *   Construct.
  */
-function tokenizeMathFenced(effects, ok, nok) {
-  const self = this
-  const tail = self.events[self.events.length - 1]
-  const initialSize =
-    tail && tail[1].type === types.linePrefix
-      ? tail[2].sliceSerialize(tail[1], true).length
-      : 0
-  let sizeOpen = 0
+export function mathFlow(isLatexDelimiters) {
+  /** @type {Construct} */
+  const nonLazyContinuation = {
+    tokenize: tokenizeNonLazyContinuation,
+    partial: true
+  }
 
-  return start
-
-  /**
-   * Start of math.
-   *
-   * ```markdown
-   * > | $$
-   *     ^
-   *   | \frac{1}{2}
-   *   | $$
-   * ```
-   *
-   * @type {State}
-   */
-  function start(code) {
-    assert(code === codes.dollarSign, 'expected `$`')
-    effects.enter('mathFlow')
-    effects.enter('mathFlowFence')
-    effects.enter('mathFlowFenceSequence')
-    return sequenceOpen(code)
+  return {
+    tokenize: tokenizeMathFenced,
+    concrete: true,
+    name: 'mathFlow',
   }
 
   /**
-   * In opening fence sequence.
-   *
-   * ```markdown
-   * > | $$
-   *      ^
-   *   | \frac{1}{2}
-   *   | $$
-   * ```
-   *
-   * @type {State}
+   * @this {TokenizeContext}
+   * @type {Tokenizer}
    */
-  function sequenceOpen(code) {
-    if (code === codes.dollarSign) {
+  function tokenizeMathFenced(effects, ok, nok) {
+    const self = this
+    const tail = self.events[self.events.length - 1]
+    const initialSize =
+      tail && tail[1].type === types.linePrefix
+        ? tail[2].sliceSerialize(tail[1], true).length
+        : 0
+    let sizeOpen = 0
+
+    return start
+
+    /**
+     * Start of math.
+     *
+     * ```markdown
+     * > | $$
+     *     ^
+     *   | \frac{1}{2}
+     *   | $$
+     * ```
+     *
+     * @type {State}
+     */
+    function start(code) {
+      if (isLatexDelimiters) {
+        assert(code === codes.backslash, 'expected `\\`')
+      }
+      else {
+        assert(code === codes.dollarSign, 'expected `$`')
+      }
+
+
+      effects.enter('mathFlow')
+      effects.enter('mathFlowFence')
+      effects.enter('mathFlowFenceSequence')
+      return sequenceOpen(code)
+    }
+
+    /**
+     * In opening fence sequence.
+     *
+     * ```markdown
+     * > | $$
+     *      ^
+     *   | \frac{1}{2}
+     *   | $$
+     * ```
+     *
+     * @type {State}
+     */
+    function sequenceOpen(code) {
+      if (isLatexDelimiters) {
+        if (sizeOpen === 0) {
+          assert(code === codes.backslash, 'expected `\\`')
+          effects.consume(code)
+          sizeOpen++
+          return sequenceOpen
+        }
+        else if (sizeOpen === 1) {
+          if (code !== codes.leftSquareBracket) {
+            return nok(code)
+          }
+
+          effects.consume(code)
+          sizeOpen++
+          return sequenceOpen
+        }
+      }
+      else {
+        if (code === codes.dollarSign) {
+          effects.consume(code)
+          sizeOpen++
+          return sequenceOpen
+        }
+      }
+
+      if (sizeOpen < 2) {
+        return nok(code)
+      }
+
+      effects.exit('mathFlowFenceSequence')
+      if (isLatexDelimiters) {
+        // metaBefore as built to jump to metaAfter without capture if it encountered a newline.
+        // Technically you can write \[ ... \] inline, so this might be scary.
+        return factorySpace(effects, metaAfter, types.whitespace)(code)
+      }
+      else {
+        return factorySpace(effects, metaBefore, types.whitespace)(code)
+      }
+    }
+
+    /**
+     * In opening fence, before meta.
+     *
+     * ```markdown
+     * > | $$asciimath
+     *       ^
+     *   | x < y
+     *   | $$
+     * ```
+     *
+     * @type {State}
+     */
+
+    function metaBefore(code) {
+      if (code === codes.eof || markdownLineEnding(code)) {
+        return metaAfter(code)
+      }
+
+      effects.enter('mathFlowFenceMeta')
+      effects.enter(types.chunkString, {contentType: constants.contentTypeString})
+      return meta(code)
+    }
+
+    /**
+     * In meta.
+     *
+     * ```markdown
+     * > | $$asciimath
+     *        ^
+     *   | x < y
+     *   | $$
+     * ```
+     *
+     * @type {State}
+     */
+    function meta(code) {
+      if (code === codes.eof || markdownLineEnding(code)) {
+        effects.exit(types.chunkString)
+        effects.exit('mathFlowFenceMeta')
+        return metaAfter(code)
+      }
+
+      if (code === codes.dollarSign) {
+        return nok(code)
+      }
+
       effects.consume(code)
-      sizeOpen++
-      return sequenceOpen
+      return meta
     }
 
-    if (sizeOpen < 2) {
-      return nok(code)
-    }
+    /**
+     * After meta.
+     *
+     * ```markdown
+     * > | $$
+     *       ^
+     *   | \frac{1}{2}
+     *   | $$
+     * ```
+     *
+     * @type {State}
+     */
+    function metaAfter(code) {
+      // Guaranteed to be eol/eof.
+      effects.exit('mathFlowFence')
 
-    effects.exit('mathFlowFenceSequence')
-    return factorySpace(effects, metaBefore, types.whitespace)(code)
-  }
+      if (self.interrupt) {
+        return ok(code)
+      }
 
-  /**
-   * In opening fence, before meta.
-   *
-   * ```markdown
-   * > | $$asciimath
-   *       ^
-   *   | x < y
-   *   | $$
-   * ```
-   *
-   * @type {State}
-   */
-
-  function metaBefore(code) {
-    if (code === codes.eof || markdownLineEnding(code)) {
-      return metaAfter(code)
-    }
-
-    effects.enter('mathFlowFenceMeta')
-    effects.enter(types.chunkString, {contentType: constants.contentTypeString})
-    return meta(code)
-  }
-
-  /**
-   * In meta.
-   *
-   * ```markdown
-   * > | $$asciimath
-   *        ^
-   *   | x < y
-   *   | $$
-   * ```
-   *
-   * @type {State}
-   */
-  function meta(code) {
-    if (code === codes.eof || markdownLineEnding(code)) {
-      effects.exit(types.chunkString)
-      effects.exit('mathFlowFenceMeta')
-      return metaAfter(code)
-    }
-
-    if (code === codes.dollarSign) {
-      return nok(code)
-    }
-
-    effects.consume(code)
-    return meta
-  }
-
-  /**
-   * After meta.
-   *
-   * ```markdown
-   * > | $$
-   *       ^
-   *   | \frac{1}{2}
-   *   | $$
-   * ```
-   *
-   * @type {State}
-   */
-  function metaAfter(code) {
-    // Guaranteed to be eol/eof.
-    effects.exit('mathFlowFence')
-
-    if (self.interrupt) {
-      return ok(code)
-    }
-
-    return effects.attempt(
-      nonLazyContinuation,
-      beforeNonLazyContinuation,
-      after
-    )(code)
-  }
-
-  /**
-   * After eol/eof in math, at a non-lazy closing fence or content.
-   *
-   * ```markdown
-   *   | $$
-   * > | \frac{1}{2}
-   *     ^
-   * > | $$
-   *     ^
-   * ```
-   *
-   * @type {State}
-   */
-  function beforeNonLazyContinuation(code) {
-    return effects.attempt(
-      {tokenize: tokenizeClosingFence, partial: true},
-      after,
-      contentStart
-    )(code)
-  }
-
-  /**
-   * Before math content, definitely not before a closing fence.
-   *
-   * ```markdown
-   *   | $$
-   * > | \frac{1}{2}
-   *     ^
-   *   | $$
-   * ```
-   *
-   * @type {State}
-   */
-  function contentStart(code) {
-    return (
-      initialSize
-        ? factorySpace(
-            effects,
-            beforeContentChunk,
-            types.linePrefix,
-            initialSize + 1
-          )
-        : beforeContentChunk
-    )(code)
-  }
-
-  /**
-   * Before math content, after optional prefix.
-   *
-   * ```markdown
-   *   | $$
-   * > | \frac{1}{2}
-   *     ^
-   *   | $$
-   * ```
-   *
-   * @type {State}
-   */
-  function beforeContentChunk(code) {
-    if (code === codes.eof) {
-      return after(code)
-    }
-
-    if (markdownLineEnding(code)) {
       return effects.attempt(
         nonLazyContinuation,
         beforeNonLazyContinuation,
@@ -230,120 +199,105 @@ function tokenizeMathFenced(effects, ok, nok) {
       )(code)
     }
 
-    effects.enter('mathFlowValue')
-    return contentChunk(code)
-  }
-
-  /**
-   * In math content.
-   *
-   * ```markdown
-   *   | $$
-   * > | \frac{1}{2}
-   *      ^
-   *   | $$
-   * ```
-   *
-   * @type {State}
-   */
-  function contentChunk(code) {
-    if (code === codes.eof || markdownLineEnding(code)) {
-      effects.exit('mathFlowValue')
-      return beforeContentChunk(code)
-    }
-
-    effects.consume(code)
-    return contentChunk
-  }
-
-  /**
-   * After math (ha!).
-   *
-   * ```markdown
-   *   | $$
-   *   | \frac{1}{2}
-   * > | $$
-   *       ^
-   * ```
-   *
-   * @type {State}
-   */
-  function after(code) {
-    effects.exit('mathFlow')
-    return ok(code)
-  }
-
-  /** @type {Tokenizer} */
-  function tokenizeClosingFence(effects, ok, nok) {
-    let size = 0
-
-    assert(self.parser.constructs.disable.null, 'expected `disable.null`')
     /**
-     * Before closing fence, at optional whitespace.
+     * After eol/eof in math, at a non-lazy closing fence or content.
      *
      * ```markdown
      *   | $$
-     *   | \frac{1}{2}
-     * > | $$
+     * > | \frac{1}{2}
      *     ^
-     * ```
-     */
-    return factorySpace(
-      effects,
-      beforeSequenceClose,
-      types.linePrefix,
-      self.parser.constructs.disable.null.includes('codeIndented')
-        ? undefined
-        : constants.tabSize
-    )
-
-    /**
-     * In closing fence, after optional whitespace, at sequence.
-     *
-     * ```markdown
-     *   | $$
-     *   | \frac{1}{2}
      * > | $$
      *     ^
      * ```
      *
      * @type {State}
      */
-    function beforeSequenceClose(code) {
-      effects.enter('mathFlowFence')
-      effects.enter('mathFlowFenceSequence')
-      return sequenceClose(code)
+    function beforeNonLazyContinuation(code) {
+      return effects.attempt(
+        {tokenize: tokenizeClosingFence, partial: true},
+        after,
+        contentStart
+      )(code)
     }
 
     /**
-     * In closing fence sequence.
+     * Before math content, definitely not before a closing fence.
      *
      * ```markdown
      *   | $$
-     *   | \frac{1}{2}
-     * > | $$
+     * > | \frac{1}{2}
+     *     ^
+     *   | $$
+     * ```
+     *
+     * @type {State}
+     */
+    function contentStart(code) {
+      return (
+        initialSize
+          ? factorySpace(
+            effects,
+            beforeContentChunk,
+            types.linePrefix,
+            initialSize + 1
+          )
+          : beforeContentChunk
+      )(code)
+    }
+
+    /**
+     * Before math content, after optional prefix.
+     *
+     * ```markdown
+     *   | $$
+     * > | \frac{1}{2}
+     *     ^
+     *   | $$
+     * ```
+     *
+     * @type {State}
+     */
+    function beforeContentChunk(code) {
+      if (code === codes.eof) {
+        return after(code)
+      }
+
+      if (markdownLineEnding(code)) {
+        return effects.attempt(
+          nonLazyContinuation,
+          beforeNonLazyContinuation,
+          after
+        )(code)
+      }
+
+      effects.enter('mathFlowValue')
+      return contentChunk(code)
+    }
+
+    /**
+     * In math content.
+     *
+     * ```markdown
+     *   | $$
+     * > | \frac{1}{2}
      *      ^
+     *   | $$
      * ```
      *
      * @type {State}
      */
-    function sequenceClose(code) {
-      if (code === codes.dollarSign) {
-        size++
-        effects.consume(code)
-        return sequenceClose
+    function contentChunk(code) {
+      if (code === codes.eof || markdownLineEnding(code)) {
+        effects.exit('mathFlowValue')
+        return beforeContentChunk(code)
       }
 
-      if (size < sizeOpen) {
-        return nok(code)
-      }
-
-      effects.exit('mathFlowFenceSequence')
-      return factorySpace(effects, afterSequenceClose, types.whitespace)(code)
+      effects.consume(code)
+      return contentChunk
     }
 
     /**
-     * After closing fence sequence, after optional whitespace.
+     * After math (ha!).
      *
      * ```markdown
      *   | $$
@@ -354,41 +308,159 @@ function tokenizeMathFenced(effects, ok, nok) {
      *
      * @type {State}
      */
-    function afterSequenceClose(code) {
-      if (code === codes.eof || markdownLineEnding(code)) {
-        effects.exit('mathFlowFence')
-        return ok(code)
-      }
-
-      return nok(code)
-    }
-  }
-}
-
-/**
- * @this {TokenizeContext}
- * @type {Tokenizer}
- */
-function tokenizeNonLazyContinuation(effects, ok, nok) {
-  const self = this
-
-  return start
-
-  /** @type {State} */
-  function start(code) {
-    if (code === null) {
+    function after(code) {
+      effects.exit('mathFlow')
       return ok(code)
     }
 
-    assert(markdownLineEnding(code), 'expected eol')
-    effects.enter(types.lineEnding)
-    effects.consume(code)
-    effects.exit(types.lineEnding)
-    return lineStart
+    /** @type {Tokenizer} */
+    function tokenizeClosingFence(effects, ok, nok) {
+      let size = 0
+
+      assert(self.parser.constructs.disable.null, 'expected `disable.null`')
+      /**
+       * Before closing fence, at optional whitespace.
+       *
+       * ```markdown
+       *   | $$
+       *   | \frac{1}{2}
+       * > | $$
+       *     ^
+       * ```
+       */
+      return factorySpace(
+        effects,
+        beforeSequenceClose,
+        types.linePrefix,
+        self.parser.constructs.disable.null.includes('codeIndented')
+          ? undefined
+          : constants.tabSize
+      )
+
+      /**
+       * In closing fence, after optional whitespace, at sequence.
+       *
+       * ```markdown
+       *   | $$
+       *   | \frac{1}{2}
+       * > | $$
+       *     ^
+       * ```
+       *
+       * @type {State}
+       */
+      function beforeSequenceClose(code) {
+        effects.enter('mathFlowFence')
+        effects.enter('mathFlowFenceSequence')
+        return sequenceClose(code)
+      }
+
+      /**
+       * In closing fence sequence.
+       *
+       * ```markdown
+       *   | $$
+       *   | \frac{1}{2}
+       * > | $$
+       *      ^
+       * ```
+       *
+       * @type {State}
+       */
+      function sequenceClose(code) {
+        if (isLatexDelimiters) {
+          if (size === 0) {
+            if (code !== codes.backslash) {
+              // TODO should this keep capturing instead?
+              return nok(code)
+            }
+
+            size++
+            effects.consume(code)
+            return sequenceClose
+          }
+          else if (size === 1) {
+            if (code !== codes.rightSquareBracket) {
+              // TODO should this keep capturing instead?
+              return nok(code)
+            }
+            size++
+            effects.consume(code)
+            return sequenceClose
+          }
+        }
+        else {
+          if (code === codes.dollarSign) {
+            size++
+            effects.consume(code)
+            return sequenceClose
+          }
+        }
+
+        if (size < sizeOpen) {
+          return nok(code)
+        }
+
+        effects.exit('mathFlowFenceSequence')
+        return factorySpace(effects, afterSequenceClose, types.whitespace)(code)
+      }
+
+      /**
+       * After closing fence sequence, after optional whitespace.
+       *
+       * ```markdown
+       *   | $$
+       *   | \frac{1}{2}
+       * > | $$
+       *       ^
+       * ```
+       *
+       * @type {State}
+       */
+      function afterSequenceClose(code) {
+        if (code === codes.eof || markdownLineEnding(code)) {
+          effects.exit('mathFlowFence')
+          return ok(code)
+        }
+
+        return nok(code)
+      }
+    }
   }
 
-  /** @type {State} */
-  function lineStart(code) {
-    return self.parser.lazy[self.now().line] ? nok(code) : ok(code)
+  /**
+   * @this {TokenizeContext}
+   * @type {Tokenizer}
+   */
+  function tokenizeNonLazyContinuation(effects, ok, nok) {
+    const self = this
+
+    return start
+
+    /** @type {State} */
+    function start(code) {
+      if (code === null) {
+        return ok(code)
+      }
+
+      const isCodeLineEnding = markdownLineEnding(code)
+      if (!isLatexDelimiters) {
+        assert(isCodeLineEnding, 'expected eol')
+      }
+
+      if (!isCodeLineEnding) {
+        return ok(code)
+      }
+
+      effects.enter(types.lineEnding)
+      effects.consume(code)
+      effects.exit(types.lineEnding)
+      return lineStart
+    }
+
+    /** @type {State} */
+    function lineStart(code) {
+      return self.parser.lazy[self.now().line] ? nok(code) : ok(code)
+    }
   }
 }

--- a/dev/lib/syntax.js
+++ b/dev/lib/syntax.js
@@ -18,7 +18,13 @@ import {mathText} from './math-text.js'
  */
 export function math(options) {
   return {
-    flow: {[codes.dollarSign]: mathFlow},
-    text: {[codes.dollarSign]: mathText(options)}
+    flow: {
+      [codes.dollarSign]: mathFlow(false),
+      [codes.backslash]: mathFlow(true)
+    },
+    text: {
+      [codes.dollarSign]: mathText(false, options),
+      [codes.backslash]: mathText(true, options),
+    }
   }
 }


### PR DESCRIPTION
Adds support for detecting `\( ... \)` and `\[ ... \]`
This added functionality is an augmentation of that existing TeX based delimiter detection which is based on `$...$` and `$$...$$`